### PR TITLE
Creating TournamentParticipations

### DIFF
--- a/Helpers/Identity.Api/JwtGenerator.cs
+++ b/Helpers/Identity.Api/JwtGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Text;
 
 using Bogus;
 
@@ -22,35 +23,12 @@ public static class JwtGenerator
     {
         Logger = Log.ForContext(typeof(JwtGenerator));
 
-        var keyString = ConfigurationHelper.Configuration["JwtSettings:Key"];
-        if (string.IsNullOrEmpty(keyString))
-        {
-            var ex = new InvalidOperationException("JWT Key not found in configuration");
-            Logger.Error(ex, "JWT Key not found in configuration");
-            throw ex;
-        }
+        var jwtSettings = new JwtOptions();
+        ConfigurationHelper.Configuration.GetSection("JwtSettings").Bind(jwtSettings);
 
-        Key = System.Text.Encoding.UTF8.GetBytes(keyString);
-
-        var issuer = ConfigurationHelper.Configuration["JwtSettings:Issuer"]!;
-        if (string.IsNullOrEmpty(issuer))
-        {
-            var ex = new InvalidOperationException("JWT Issuer not found in configuration");
-            Logger.Error(ex, "JWT Issuer not found in configuration");
-            throw ex;
-        }
-
-        CustomIssuer = issuer;
-
-        var audience = ConfigurationHelper.Configuration["JwtSettings:Audience"];
-        if (string.IsNullOrEmpty(audience))
-        {
-            var ex = new InvalidOperationException("JWT Audience not found in configuration");
-            Logger.Error(ex, "JWT Audience not found in configuration");
-            throw ex;
-        }
-
-        CustomAudience = audience;
+        Key = Encoding.UTF8.GetBytes(jwtSettings.Key);
+        CustomIssuer = jwtSettings.Issuer;
+        CustomAudience = jwtSettings.Audience;
     }
 
     public static string GenerateToken(

--- a/Helpers/Identity.Api/JwtOptions.cs
+++ b/Helpers/Identity.Api/JwtOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Identity.Api;
+
+public class JwtOptions
+{
+    public string Key { get; set; } = String.Empty;
+    public string Issuer { get; set; } = "https://id.andhernand.com";
+    public string Audience { get; set; } = "https://golfleague.andhernand.com/api";
+}

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,3 +1,12 @@
+sp_configure 'show advanced options', 1;
+GO
+RECONFIGURE;
+GO
+sp_configure 'max server memory', 4096;
+GO
+RECONFIGURE;
+GO
+
 IF (DB_ID(N'GolfLeague') IS NULL)
 	BEGIN
 		PRINT 'Creating the database.';

--- a/src/GolfLeague.Api/Endpoints/TournamentParticipations/CreateGolferTournamentParticipationEndpoint.cs
+++ b/src/GolfLeague.Api/Endpoints/TournamentParticipations/CreateGolferTournamentParticipationEndpoint.cs
@@ -8,21 +8,22 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GolfLeague.Api.Endpoints.TournamentParticipations;
 
-public static class CreateTournamentParticipationEndpoint
+public static class CreateGolferTournamentParticipationEndpoint
 {
-    private const string Name = "CreateTournamentParticipation";
+    private const string Name = "CreateGolferTournamentParticipation";
 
-    public static IEndpointRouteBuilder MapCreateTournamentParticipation(this IEndpointRouteBuilder app)
+    public static IEndpointRouteBuilder MapCreateGolferTournamentParticipation(this IEndpointRouteBuilder app)
     {
-        app.MapPost(GolfApiEndpoints.TournamentParticipation.Create, async (
-                CreateTournamentParticipationsRequest request,
+        app.MapPost(GolfApiEndpoints.Golfers.GolferTournamentParticipations, async (
+                int id,
                 ITournamentParticipationService service,
-                CancellationToken token = default) =>
+                CreateGolferTournamentParticipationRequest request,
+                CancellationToken cancellationToken = default) =>
             {
-                var tournamentParticipation = request.MapToTournamentParticipation();
-                await service.CreateAsync(tournamentParticipation, token);
+                var participation = request.MapToTournamentParticipation(id);
+                _ = await service.CreateAsync(participation, cancellationToken);
 
-                var response = tournamentParticipation.MapToResponse();
+                var response = participation.MapToResponse();
                 return TypedResults.CreatedAtRoute(
                     response,
                     GetTournamentParticipationByIdEndpoint.Name,

--- a/src/GolfLeague.Api/Endpoints/TournamentParticipations/CreateTournamentGolferParticipationEndpoint.cs
+++ b/src/GolfLeague.Api/Endpoints/TournamentParticipations/CreateTournamentGolferParticipationEndpoint.cs
@@ -1,0 +1,42 @@
+﻿using GolfLeague.Api.Auth;
+using GolfLeague.Api.Mapping;
+using GolfLeague.Application.Services;
+using GolfLeague.Contracts.Requests;
+using GolfLeague.Contracts.Responses;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace GolfLeague.Api.Endpoints.TournamentParticipations;
+
+public static class CreateTournamentGolferParticipationEndpoint
+{
+    private const string Name = "CreateTournamentGolferParticipation";
+
+    public static IEndpointRouteBuilder MapCreateTournamentGolferParticipationEndpoint(this IEndpointRouteBuilder app)
+    {
+        app.MapPost(GolfApiEndpoints.Tournaments.TournamentGolferParticipations, async (
+                int id,
+                ITournamentParticipationService service,
+                CreateTournamentGolferParticipationRequest request,
+                CancellationToken cancellationToken = default) =>
+            {
+                var participation = request.MapToTournamentParticipation(id);
+                _ = await service.CreateAsync(participation, cancellationToken);
+
+                var response = participation.MapToResponse();
+                return TypedResults.CreatedAtRoute(
+                    response,
+                    GetTournamentParticipationByIdEndpoint.Name,
+                    new { golferId = response.GolferId, tournamentId = response.TournamentId, year = response.Year });
+            })
+            .WithName(Name)
+            .WithTags(GolfApiEndpoints.TournamentParticipation.Tag)
+            .Produces<TournamentParticipationResponse>(StatusCodes.Status201Created)
+            .Produces<ValidationProblemDetails>(
+                StatusCodes.Status400BadRequest,
+                contentType: "application/problem+json")
+            .RequireAuthorization(AuthConstants.TrustedPolicyName);
+
+        return app;
+    }
+}

--- a/src/GolfLeague.Api/Endpoints/TournamentParticipations/TournamentParticipationEndpointsMapper.cs
+++ b/src/GolfLeague.Api/Endpoints/TournamentParticipations/TournamentParticipationEndpointsMapper.cs
@@ -5,8 +5,9 @@ public static class TournamentParticipationEndpointsMapper
     public static IEndpointRouteBuilder MapTournamentParticipationEndpoints(this IEndpointRouteBuilder app)
     {
         return app
-            .MapCreateTournamentParticipation()
             .MapGetTournamentParticipationById()
-            .MapDeleteTournamentParticipation();
+            .MapDeleteTournamentParticipation()
+            .MapCreateGolferTournamentParticipation()
+            .MapCreateTournamentGolferParticipationEndpoint();
     }
 }

--- a/src/GolfLeague.Api/GolfApiEndpoints.cs
+++ b/src/GolfLeague.Api/GolfApiEndpoints.cs
@@ -14,6 +14,7 @@ public static class GolfApiEndpoints
         public const string Update = $"{Base}/{{id:int}}";
         public const string Delete = $"{Base}/{{id:int}}";
         public const string Tag = "Golfers";
+        public const string GolferTournamentParticipations = $"{Base}/{{id:int}}/tournamentparticipations";
     }
 
     public static class Tournaments
@@ -25,6 +26,7 @@ public static class GolfApiEndpoints
         public const string Update = $"{Base}/{{id:int}}";
         public const string Delete = $"{Base}/{{id:int}}";
         public const string Tag = "Tournaments";
+        public const string TournamentGolferParticipations = $"{Base}/{{id:int}}/tournamentparticipations";
     }
 
     public static class TournamentParticipation

--- a/src/GolfLeague.Api/Mapping/ContractMapping.cs
+++ b/src/GolfLeague.Api/Mapping/ContractMapping.cs
@@ -91,15 +91,6 @@ public static class ContractMapping
         };
     }
 
-    public static TournamentParticipation MapToTournamentParticipation(
-        this CreateTournamentParticipationsRequest request)
-    {
-        return new TournamentParticipation
-        {
-            GolferId = request.GolferId, TournamentId = request.TournamentId, Year = request.Year
-        };
-    }
-
     public static TournamentDetailResponse MapToResponse(this TournamentDetail tournamentDetail)
     {
         return new TournamentDetailResponse
@@ -119,6 +110,26 @@ public static class ContractMapping
             FirstName = participationDetail.FirstName,
             LastName = participationDetail.LastName,
             Year = participationDetail.Year
+        };
+    }
+
+    public static TournamentParticipation MapToTournamentParticipation(
+        this CreateGolferTournamentParticipationRequest request,
+        int golferId)
+    {
+        return new TournamentParticipation
+        {
+            GolferId = golferId, TournamentId = request.TournamentId, Year = request.Year
+        };
+    }
+
+    public static TournamentParticipation MapToTournamentParticipation(
+        this CreateTournamentGolferParticipationRequest request,
+        int tournamentId)
+    {
+        return new TournamentParticipation
+        {
+            GolferId = request.GolferId, TournamentId = tournamentId, Year = request.Year
         };
     }
 }

--- a/src/GolfLeague.Api/Options/JwtOptions.cs
+++ b/src/GolfLeague.Api/Options/JwtOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace GolfLeague.Api.Options;
+
+public class JwtOptions
+{
+    public string Key { get; set; } = String.Empty;
+    public string Issuer { get; set; } = "https://id.andhernand.com";
+    public string Audience { get; set; } = "https://golfleague.andhernand.com/api";
+}

--- a/src/GolfLeague.Api/Program.cs
+++ b/src/GolfLeague.Api/Program.cs
@@ -4,6 +4,7 @@ using GolfLeague.Api.Auth;
 using GolfLeague.Api.Endpoints;
 using GolfLeague.Api.Health;
 using GolfLeague.Api.Mapping;
+using GolfLeague.Api.Options;
 using GolfLeague.Api.Swagger;
 using GolfLeague.Application;
 
@@ -16,13 +17,16 @@ using Serilog;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 var builder = WebApplication.CreateBuilder(args);
-var config = builder.Configuration;
+using var config = builder.Configuration;
 
 Log.Logger = new LoggerConfiguration()
     .ReadFrom.Configuration(config)
     .CreateLogger();
 
 builder.Host.UseSerilog();
+
+var jwtOptions = new JwtOptions();
+config.GetSection("JwtSettings").Bind(jwtOptions);
 
 builder.Services.AddAuthentication(options =>
     {
@@ -33,9 +37,9 @@ builder.Services.AddAuthentication(options =>
     .AddJwtBearer(options =>
     {
         options.TokenValidationParameters.IssuerSigningKey = new SymmetricSecurityKey(
-            Encoding.UTF8.GetBytes(config["JwtSettings:Key"]!));
-        options.TokenValidationParameters.ValidIssuer = config["JwtSettings:Issuer"];
-        options.TokenValidationParameters.ValidAudience = config["JwtSettings:Audience"];
+            Encoding.UTF8.GetBytes(jwtOptions.Key));
+        options.TokenValidationParameters.ValidIssuer = jwtOptions.Issuer;
+        options.TokenValidationParameters.ValidAudience = jwtOptions.Audience;
         options.TokenValidationParameters.ClockSkew = TimeSpan.FromSeconds(5);
         options.TokenValidationParameters.ValidateIssuerSigningKey = true;
         options.TokenValidationParameters.ValidateLifetime = true;

--- a/src/GolfLeague.Application/Validators/GolferValidator.cs
+++ b/src/GolfLeague.Application/Validators/GolferValidator.cs
@@ -29,12 +29,13 @@ public class GolferValidator : AbstractValidator<Golfer>
             });
 
         RuleFor(m => m.JoinDate)
-            .NotEmpty();
-
-        RuleFor(m => m.JoinDate.Year)
-            .LessThanOrEqualTo(DateTime.UtcNow.Year)
-            .OverridePropertyName("JoinDate")
-            .WithName("Join Date");
+            .NotEmpty()
+            .DependentRules(() =>
+            {
+                RuleFor(m => m.JoinDate.Year)
+                    .LessThanOrEqualTo(DateTime.UtcNow.Year)
+                    .OverridePropertyName("JoinDate");
+            });
 
         RuleFor(m => m.Handicap)
             .InclusiveBetween(0, 54)

--- a/src/GolfLeague.Application/Validators/TournamentParticipationValidator.cs
+++ b/src/GolfLeague.Application/Validators/TournamentParticipationValidator.cs
@@ -8,19 +8,45 @@ namespace GolfLeague.Application.Validators;
 public class TournamentParticipationValidator : AbstractValidator<TournamentParticipation>
 {
     private readonly ITournamentParticipationRepository _repository;
+    private readonly ITournamentRepository _tournamentRepository;
+    private readonly IGolferRepository _golferRepository;
 
-    public TournamentParticipationValidator(ITournamentParticipationRepository repository)
+    public TournamentParticipationValidator(
+        ITournamentParticipationRepository repository,
+        ITournamentRepository tournamentRepository,
+        IGolferRepository golferRepository)
     {
         _repository = repository;
+        _tournamentRepository = tournamentRepository;
+        _golferRepository = golferRepository;
 
         RuleFor(x => x.GolferId)
-            .NotEmpty();
+            .NotEmpty()
+            .DependentRules(() =>
+            {
+                RuleFor(x => x.GolferId)
+                    .MustAsync(ValidateGolferIdAsync)
+                    .OverridePropertyName("GolferId")
+                    .WithMessage("'Golfer Id' does not exists in the system");
+            });
 
         RuleFor(x => x.TournamentId)
-            .NotEmpty();
+            .NotEmpty()
+            .DependentRules(() =>
+            {
+                RuleFor(x => x.TournamentId)
+                    .MustAsync(ValidateTournamentIdAsync)
+                    .OverridePropertyName("TournamentId")
+                    .WithMessage("'Tournament Id' does not exists in the system");
+            });
 
         RuleFor(x => x.Year)
-            .NotEmpty();
+            .NotEmpty()
+            .DependentRules(() =>
+            {
+                RuleFor(x => x.Year)
+                    .InclusiveBetween(1916, DateTime.UtcNow.Year);
+            });
 
         RuleFor(x => x)
             .MustAsync(ValidateTournamentParticipationAsync)
@@ -29,10 +55,23 @@ public class TournamentParticipationValidator : AbstractValidator<TournamentPart
             .When(x => x.GolferId != default && x.TournamentId != default && x.Year != default);
     }
 
+    private async Task<bool> ValidateGolferIdAsync(int golferId, CancellationToken token)
+    {
+        var exists = await _golferRepository.ExistsByIdAsync(golferId, token);
+        return exists;
+    }
+
+    private async Task<bool> ValidateTournamentIdAsync(int tournamentId, CancellationToken token)
+    {
+        var exists = await _tournamentRepository.ExistsByIdAsync(tournamentId, token);
+        return exists;
+    }
+
     private async Task<bool> ValidateTournamentParticipationAsync(
         TournamentParticipation tournamentParticipation,
         CancellationToken cancellationToken = default)
     {
-        return !await _repository.ExistsByIdAsync(tournamentParticipation, cancellationToken);
+        var exists = await _repository.ExistsByIdAsync(tournamentParticipation, cancellationToken);
+        return !exists;
     }
 }

--- a/src/GolfLeague.Contracts/Requests/CreateGolferTournamentParticipationRequest.cs
+++ b/src/GolfLeague.Contracts/Requests/CreateGolferTournamentParticipationRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace GolfLeague.Contracts.Requests;
+
+public class CreateGolferTournamentParticipationRequest
+{
+    public int TournamentId { get; set; }
+    public int Year { get; set; }
+}

--- a/src/GolfLeague.Contracts/Requests/CreateTournamentGolferParticipationRequest.cs
+++ b/src/GolfLeague.Contracts/Requests/CreateTournamentGolferParticipationRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace GolfLeague.Contracts.Requests;
+
+public class CreateTournamentGolferParticipationRequest
+{
+    public int GolferId { get; set; }
+    public int Year { get; set; }
+}

--- a/src/GolfLeague.Contracts/Requests/CreateTournamentParticipationsRequest.cs
+++ b/src/GolfLeague.Contracts/Requests/CreateTournamentParticipationsRequest.cs
@@ -1,8 +1,0 @@
-﻿namespace GolfLeague.Contracts.Requests;
-
-public class CreateTournamentParticipationsRequest
-{
-    public required int GolferId { get; init; }
-    public required int TournamentId { get; init; }
-    public required int Year { get; init; }
-}

--- a/tests/GolfLeague.Api.Tests.Integration/Endpoints/Golfer/GetAllGolfersEndpointTests.cs
+++ b/tests/GolfLeague.Api.Tests.Integration/Endpoints/Golfer/GetAllGolfersEndpointTests.cs
@@ -18,7 +18,7 @@ public abstract class GetAllGolfersEndpointTests
             using var client = Mother.CreateAuthorizedClient(golfApiFactory, isAdmin: true);
             var createdGolfer = await Mother.CreateGolferAsync(client);
             var createdTournament = await Mother.CreateTournamentAsync(client);
-            var createdTournamentParticipation = await Mother.CreateTournamentParticipationAsync(
+            var createdTournamentParticipation = await Mother.CreateGolferTournamentParticipationAsync(
                 client,
                 createdGolfer.GolferId,
                 createdTournament.TournamentId);

--- a/tests/GolfLeague.Api.Tests.Integration/Endpoints/Golfer/GetGolferByIdEndpointTests.cs
+++ b/tests/GolfLeague.Api.Tests.Integration/Endpoints/Golfer/GetGolferByIdEndpointTests.cs
@@ -62,7 +62,7 @@ public class GetGolferByIdEndpointTests(GolfApiFactory golfApiFactory) : IClassF
 
         var createdGolfer = await Mother.CreateGolferAsync(client);
         var createdTournament = await Mother.CreateTournamentAsync(client);
-        var createdTournamentParticipation = await Mother.CreateTournamentParticipationAsync(
+        var createdTournamentParticipation = await Mother.CreateGolferTournamentParticipationAsync(
             client,
             createdGolfer.GolferId,
             createdTournament.TournamentId);
@@ -112,5 +112,18 @@ public class GetGolferByIdEndpointTests(GolfApiFactory golfApiFactory) : IClassF
 
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task HealthCheck_WhenHealthy_ShouldReturnHealthy()
+    {
+        using var client = golfApiFactory.CreateClient();
+
+        var response = await client.GetAsync("/_health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var message = await response.Content.ReadAsStringAsync();
+        message.Should().Be("Healthy");
     }
 }

--- a/tests/GolfLeague.Api.Tests.Integration/Endpoints/Tournament/GetAllTournamentsEndpointTests.cs
+++ b/tests/GolfLeague.Api.Tests.Integration/Endpoints/Tournament/GetAllTournamentsEndpointTests.cs
@@ -18,7 +18,7 @@ public abstract class GetAllTournamentsEndpointTests
             using var client = Mother.CreateAuthorizedClient(golfApiFactory, isAdmin: true);
             var createdGolfer = await Mother.CreateGolferAsync(client);
             var createdTournament = await Mother.CreateTournamentAsync(client);
-            var createdTournamentParticipation = await Mother.CreateTournamentParticipationAsync(
+            var createdTournamentParticipation = await Mother.CreateTournamentGolferParticipationAsync(
                 client,
                 createdGolfer.GolferId,
                 createdTournament.TournamentId);

--- a/tests/GolfLeague.Api.Tests.Integration/Endpoints/Tournament/GetTournamentByIdEndpointTests.cs
+++ b/tests/GolfLeague.Api.Tests.Integration/Endpoints/Tournament/GetTournamentByIdEndpointTests.cs
@@ -59,7 +59,7 @@ public class GetTournamentByIdEndpointTests(GolfApiFactory golfApiFactory) : ICl
         using var client = Mother.CreateAuthorizedClient(golfApiFactory, isAdmin: true);
         var createdGolfer = await Mother.CreateGolferAsync(client);
         var createdTournament = await Mother.CreateTournamentAsync(client);
-        var createdTournamentParticipation = await Mother.CreateTournamentParticipationAsync(
+        var createdTournamentParticipation = await Mother.CreateTournamentGolferParticipationAsync(
             client,
             createdGolfer.GolferId,
             createdTournament.TournamentId);

--- a/tests/GolfLeague.Api.Tests.Integration/Endpoints/TournamentParticipation/DeleteTournamentParticipationEndpointTests.cs
+++ b/tests/GolfLeague.Api.Tests.Integration/Endpoints/TournamentParticipation/DeleteTournamentParticipationEndpointTests.cs
@@ -13,7 +13,7 @@ public class DeleteTournamentParticipationEndpointTests(GolfApiFactory golfApiFa
         using var client = Mother.CreateAuthorizedClient(golfApiFactory, isAdmin: true);
         var createdGolfer = await Mother.CreateGolferAsync(client);
         var createdTournament = await Mother.CreateTournamentAsync(client);
-        var createdTournamentParticipation = await Mother.CreateTournamentParticipationAsync(
+        var createdTournamentParticipation = await Mother.CreateTournamentGolferParticipationAsync(
             client,
             createdGolfer.GolferId,
             createdTournament.TournamentId);

--- a/tests/GolfLeague.Api.Tests.Integration/Endpoints/TournamentParticipation/GetTournamentParticipationByIdEndpointTests.cs
+++ b/tests/GolfLeague.Api.Tests.Integration/Endpoints/TournamentParticipation/GetTournamentParticipationByIdEndpointTests.cs
@@ -17,7 +17,7 @@ public class GetTournamentParticipationByIdEndpointTests(GolfApiFactory golfApiF
         using var client = Mother.CreateAuthorizedClient(golfApiFactory, isAdmin: true);
         var createdGolfer = await Mother.CreateGolferAsync(client);
         var createdTournament = await Mother.CreateTournamentAsync(client);
-        var createdTournamentParticipation = await Mother.CreateTournamentParticipationAsync(
+        var createdTournamentParticipation = await Mother.CreateGolferTournamentParticipationAsync(
             client,
             createdGolfer.GolferId,
             createdTournament.TournamentId);

--- a/tests/GolfLeague.Api.Tests.Integration/JwtGenerator.cs
+++ b/tests/GolfLeague.Api.Tests.Integration/JwtGenerator.cs
@@ -4,6 +4,8 @@ using System.Text;
 
 using Bogus;
 
+using GolfLeague.Api.Options;
+
 using Microsoft.IdentityModel.Tokens;
 
 namespace GolfLeague.Api.Tests.Integration;
@@ -18,9 +20,12 @@ public static class JwtGenerator
 
     static JwtGenerator()
     {
-        Key = Encoding.UTF8.GetBytes(GetConfigurationValueOrThrow("JwtSettings:Key"));
-        CustomIssuer = GetConfigurationValueOrThrow("JwtSettings:Issuer");
-        CustomAudience = GetConfigurationValueOrThrow("JwtSettings:Audience");
+        var jwtOptions = new JwtOptions();
+        ConfigurationHelper.Configuration.GetSection("JwtSettings").Bind(jwtOptions);
+
+        Key = Encoding.UTF8.GetBytes(jwtOptions.Key);
+        CustomIssuer = jwtOptions.Issuer;
+        CustomAudience = jwtOptions.Audience;
     }
 
     public static string GenerateToken(
@@ -74,11 +79,5 @@ public static class JwtGenerator
         public const string UserId = "userid";
         public const string Admin = "admin";
         public const string TrustedUser = "trusted_user";
-    }
-
-    private static string GetConfigurationValueOrThrow(string key)
-    {
-        return ConfigurationHelper.Configuration[key]
-               ?? throw new InvalidOperationException($"{key} not found configuration");
     }
 }

--- a/tests/GolfLeague.Api.Tests.Integration/Mother.cs
+++ b/tests/GolfLeague.Api.Tests.Integration/Mother.cs
@@ -43,18 +43,34 @@ public static class Mother
         return tournament!;
     }
 
-    public static async Task<TournamentParticipationResponse> CreateTournamentParticipationAsync(
+    public static async Task<TournamentParticipationResponse> CreateGolferTournamentParticipationAsync(
         HttpClient client,
         int golferId,
         int tournamentId)
     {
-        var tournamentParticipationsRequest = new CreateTournamentParticipationsRequest
+        var request = new CreateGolferTournamentParticipationRequest
         {
-            GolferId = golferId, TournamentId = tournamentId, Year = GenerateYear()
+            TournamentId = tournamentId, Year = GenerateYear()
         };
 
         var response = await client.PostAsJsonAsync(
-            TournamentParticipationsApiBasePath, tournamentParticipationsRequest);
+            $"{GolfersApiBasePath}/{golferId}/tournamentparticipations",
+            request);
+
+        var tournamentParticipation = await response.Content.ReadFromJsonAsync<TournamentParticipationResponse>();
+        return tournamentParticipation!;
+    }
+
+    public static async Task<TournamentParticipationResponse> CreateTournamentGolferParticipationAsync(
+        HttpClient client,
+        int golferId,
+        int tournamentId)
+    {
+        var request = new CreateTournamentGolferParticipationRequest { GolferId = golferId, Year = GenerateYear() };
+
+        var response = await client.PostAsJsonAsync(
+            $"{TournamentsApiBasePath}/{tournamentId}/tournamentparticipations",
+            request);
 
         var tournamentParticipation = await response.Content.ReadFromJsonAsync<TournamentParticipationResponse>();
         return tournamentParticipation!;


### PR DESCRIPTION
/api/tournaments/{tournamentId}/tournamentparticipations
/api/golfers/{golferId}/tournamentparticipations

these endpoints add associate a golfer with a tournament or associate a
tournament with a golfer.

It is now the standard way to add tournament participation records in
the database.

closes #2