### PR TITLE
lock container version.

### DIFF
--- a/tests/GolfLeague.Api.Tests.Integration/GolfApiFactory.cs
+++ b/tests/GolfLeague.Api.Tests.Integration/GolfApiFactory.cs
@@ -20,7 +20,8 @@ public class GolfApiFactory : WebApplicationFactory<IGolfApiMarker>, IAsyncLifet
 
     private readonly MsSqlContainer _sqlContainer = new MsSqlBuilder()
         .WithPassword(SaPassword)
-        .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        .WithImage("mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04")
+        .WithEnvironment("ACCEPT_EULA", "Y")
         .WithEnvironment("MSSQL_PID", "Developer")
         .Build();
 


### PR DESCRIPTION
the latest 2022 container for MS SQL Server has some tooling changes that are not yet implemented in testcontainers. This PR locks the container version to a compatible version.